### PR TITLE
Fix severity check logic and make it configurable

### DIFF
--- a/ghasreview/app.py
+++ b/ghasreview/app.py
@@ -155,11 +155,19 @@ def onCodeScanningAlertClose():
 
     # Severity check, if not high enough, do not involve security team
     severities = current_app.config.get("GHAS_SEVERITIES")
-    if severities and alert.severity not in severities:
-        logger.debug(
-            f"Severity is not high enough to get security involved: {alert.severity}"
-        )
-        return {"message": "Severity is not high enough to get security involved, doing nothing."}
+    if severities:
+        if alert.severity not in severities:
+            logger.debug(
+                f"Severity is not high enough to get security involved: {alert.severity}"
+            )
+            return {"message": "Severity is not high enough to get security involved, doing nothing."}
+        if alert.payload.get("alert", {}).get("rule", {}).get("security_severity_level", "") not in severities:
+            logger.debug(
+                f"Security severity level is not high enough to get security involved: {alert.payload.get('alert', {}).get('rule', {}).get('security_severity_level', '')}"
+            )
+            return {"message": "Security severity level is not high enough to get security involved, doing nothing."}
+    else:
+        logger.debug("No severities provided, reopening all findings")
 
     # Check team exists
     if not alert.client.checkIfTeamExists(alert.owner, config.get("GHAS_TEAM")):

--- a/ghasreview/setup.py
+++ b/ghasreview/setup.py
@@ -28,6 +28,11 @@ def parse_arguments():
     parser_github.add_argument(
         "--ghas-comment-required", default=bool(os.environ.get("GITHUB_GHAS_COMMENT_REQUIRED", 0))
     )
+    parser_github.add_argument(
+        "--ghas-severities",
+        nargs="*",
+        default=os.environ.get("GITHUB_GHAS_SEVERITIES", "").split(",") or ["critical", "high", "error", "errors"],
+    )
 
     parser_github = parser.add_argument_group("GitHub")
     parser_github.add_argument(
@@ -63,6 +68,7 @@ def setup_logging(arguments):
     logging.debug(f"GitHub App Secret :: {arguments.github_app_secret}")
     logging.debug(f"GHAS Tool Name :: {arguments.ghas_tool_name}")
     logging.debug(f"GHAS Comment Required :: {arguments.ghas_comment_required}")
+    logging.debug(f"GHAS Severities :: {arguments.ghas_severities}")
 
 
 def validate_arguments(arguments):
@@ -102,7 +108,7 @@ def setup_app():
         "GHAS_COMMENT_REQUIRED": arguments.ghas_comment_required,
         # Tool and severities to check
         "GHAS_TOOL": arguments.ghas_tool_name,
-        "GHAS_SEVERITIES": ["critical", "high", "error", "errors"],
+        "GHAS_SEVERITIES": arguments.ghas_severities if arguments.ghas_severities else None,
         # GitHub App
         "GITHUBAPP_ID": arguments.github_app_id,
         "GITHUBAPP_KEY": app_key,


### PR DESCRIPTION
Fixes #89

Update the Reviewer app to make severity list configurable and handle security severity level.

* Add `--ghas-severities` argument to `ghasreview/setup.py` to allow configuration through environment variables or arguments.
* Modify `ghasreview/app.py` to check both `alert.severity` and `alert.payload.rule.security_severity_level` against the configurable severity list.
* Add logic to handle the case where no severity values are provided, reopening all findings.
* Log the configured severities and the results of severity checks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/advanced-security/ghas-reviewer-app/pull/90?shareId=2d285743-cb0c-408f-8e1f-360b9a6ead03).