### PR TITLE
Combine CODEOWNERS entries into a single line

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # This project is maintained with love by:
 
-* @advanced-security/oss-maintainers
-* @theztefan
+* @advanced-security/oss-maintainers @theztefan


### PR DESCRIPTION
two * do not combine - uses last matching

This pull request makes a minor update to the `.github/CODEOWNERS` file, combining the maintainers into a single line for clarity and simplicity.